### PR TITLE
Fix malloc(0) warning in clang.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ NEWS for SoftHSM -- History of user visible changes
 
 SoftHSM trunk
 
+Bugfixes:
+* Fix malloc(0) warning in clang.
+
 
 SoftHSM 1.3.5 - 2013-09-30
 

--- a/src/bin/softhsm.cpp
+++ b/src/bin/softhsm.cpp
@@ -1051,7 +1051,7 @@ int removeSessionObjs(char *dbPath) {
 char* hexStrToBin(char *objectID, size_t idLength, size_t *newLen) {
   char *bytes = NULL;
 
-  if(idLength % 2 != 0) {
+  if(idLength < 2 || idLength % 2 != 0) {
     fprintf(stderr, "Error: Invalid length on hex string.\n");
     return NULL;
   }


### PR DESCRIPTION
This patch will fix the clang warning given in this output:
https://dev.sinodun.com/analysis/softhsm/

The if-statement could have looked like this:
if(!idLength || idLength % 2 != 0)

But my version of clang (3.0-6ubuntu3) still thinks that malloc(0) can happen. However, only positive even integers can pass the checks. So *newLen will always be larger or equal to one. It thinks that idLength=1 will pass the tests.

To satisfy clang, I decided to use:
if(idLength < 2 || idLength % 2 != 0)

(My version of clang will also produce two false-positives, which are not in the report from John. It has probably been fixed in the version that John is using.)
