### PR TITLE
Copy .gitignore from SoftHSMv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Automake, autoconf, libtool
+Makefile
+Makefile.in
+core
+acinclude.m4
+aclocal.m4
+autom4te.cache
+compile
+py-compile
+confdefs.h
+config.*
+configure
+conftest
+conftest.c
+depcomp
+install-sh
+libtool
+libtool.m4
+lt*.m4
+ltmain.sh
+missing
+mkinstalldirs
+stamp-h*
+obj
+test-driver
+
+# Object files
+*.o
+
+# Libraries
+*.lib
+*.a
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib


### PR DESCRIPTION
I copied the file .gitignore from SoftHSMv2 with exception to two lines:
!win32+botan/config.h
!win32+openssl/config.h
