### PR TITLE
SOFTHSM-96: Besides changing the namespace in Botan 1.9.10, the function...

### DIFF
--- a/src/bin/softhsm.cpp
+++ b/src/bin/softhsm.cpp
@@ -309,12 +309,11 @@ int main(int argc, char *argv[]) {
 #ifdef BOTAN_PRE_1_9_10_FIX
   Botan::Library_State* state = Botan::swap_global_state(0);
   Botan::swap_global_state(state);
-#else
-  Botan::Library_State* state = Botan::Global_State_Management::swap_global_state(0);
-  Botan::Global_State_Management::swap_global_state(state);
-#endif
 
   if(state) {
+#else
+  if(Botan::Global_State_Management::global_state_exists()) {
+#endif
     was_initialized = true;
   }
 

--- a/src/lib/SoftSession.cpp
+++ b/src/lib/SoftSession.cpp
@@ -108,12 +108,11 @@ SoftSession::~SoftSession() {
 #ifdef BOTAN_PRE_1_9_10_FIX
   Botan::Library_State* state = Botan::swap_global_state(0);
   Botan::swap_global_state(state);
-#else
-  Botan::Library_State* state = Botan::Global_State_Management::swap_global_state(0);
-  Botan::Global_State_Management::swap_global_state(state);
-#endif
 
   if(state) {
+#else
+  if(Botan::Global_State_Management::global_state_exists()) {
+#endif
     DELETE_PTR(digestPipe);
     DELETE_PTR(pkEncryptor);
     DELETE_PTR(pkDecryptor);

--- a/src/lib/main.cpp
+++ b/src/lib/main.cpp
@@ -218,12 +218,11 @@ CK_RV C_Initialize(CK_VOID_PTR pInitArgs) {
 #ifdef BOTAN_PRE_1_9_10_FIX
   Botan::Library_State* state = Botan::swap_global_state(0);
   Botan::swap_global_state(state);
-#else
-  Botan::Library_State* state = Botan::Global_State_Management::swap_global_state(0);
-  Botan::Global_State_Management::swap_global_state(state);
-#endif
 
   if(state) {
+#else
+  if(Botan::Global_State_Management::global_state_exists()) {
+#endif
     was_initialized = true;
   }
 


### PR DESCRIPTION
... global_state_exists() was also introduced. No need to swap the state.
